### PR TITLE
DBML module placement compatibility

### DIFF
--- a/Assets/CompetitiveLoggerService.cs
+++ b/Assets/CompetitiveLoggerService.cs
@@ -69,6 +69,9 @@ class CompetitiveLogHandler : ILogHandler {
     }
 
     public void LogFormat(LogType logType, UnityEngine.Object context, string format, params object[] args) {
+        // DBML compatibility
+        if (args.Length > 0 && args[0].ToString().StartsWith("[BombGenerator] Bomb component list: "))
+            oldLogger.LogFormat(logType, context, format, "[BombGenerator] Bomb component list: [Removed by Competitive Logger]");
         // If log output is disabled, add the record to the queue
         if (this.isLogOutputEnabled) {
             oldLogger.LogFormat(logType, context, format, args);


### PR DESCRIPTION
Tweaks requires the presence of certain logging to denote when to replace the game's RNG. To match users who choose to not use DBML during matches, allow Competitive Logger to log this line.